### PR TITLE
Set proxy_http_version to 1.1 to work with istio 

### DIFF
--- a/infra/sneedaas/user-data.yaml
+++ b/infra/sneedaas/user-data.yaml
@@ -60,6 +60,7 @@ write_files:
                   proxy_set_header Host $host;
                   proxy_set_header X-Real-IP $remote_addr;
                   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_http_version 1.1;
               }
           }
       }


### PR DESCRIPTION
fix(nginx): set proxy_http_version to 1.1 to work with istio

Make nginx reroute correct HTTP version (1.1) via proxy.

Closes #24